### PR TITLE
Jdp241001-18 Created test suite for GruopRepository

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/domain/Group.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/Group.java
@@ -2,24 +2,22 @@ package com.kodilla.ecommercee.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
-@AllArgsConstructor
 @Entity
 @Table(name = "`GROUPS`")
 public class Group {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @NotNull
-    @Column(name = "GROUP_ID", unique = true)
+    @Column(name = "GROUP_ID", unique = true, nullable = false, updatable = false)
     private Long id;
 
     @NotNull
@@ -30,15 +28,25 @@ public class Group {
     @Column(name = "DESCRIPTION")
     private String description;
 
-    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<Product> products;
+    @OneToMany(mappedBy = "group", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.EAGER)
+    private List<Product> products = new ArrayList<>();
 
     @NotNull
     @Column(name = "CREATED_AT", updatable = false)
     private LocalDateTime createdAt;
 
+    public Group(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
+    }
+
+    @PreRemove
+    protected void onRemove() {
+        products.forEach(product -> product.setGroup(null));
     }
 }

--- a/src/main/java/com/kodilla/ecommercee/domain/Group.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/Group.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,7 +43,7 @@ public class Group {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = LocalDateTime.now();
+        createdAt = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
     }
 
     @PreRemove

--- a/src/main/java/com/kodilla/ecommercee/domain/Product.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/Product.java
@@ -2,24 +2,23 @@ package com.kodilla.ecommercee.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @NoArgsConstructor
-@AllArgsConstructor
 @Entity
 @Table(name = "PRODUCTS")
 public class Product {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @NotNull
-    @Column(name = "PRODUCT_ID", unique = true)
+    @Column(name = "PRODUCT_ID", unique = true, nullable = false)
     private Long id;
 
     @NotNull
@@ -45,6 +44,14 @@ public class Product {
     @NotNull
     @Column(name = "CREATED_AT", updatable = false)
     private LocalDateTime createdAt;
+
+    public Product(String name, String description, BigDecimal price, Integer stock, Group group) {
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.stock = stock;
+        this.group = group;
+    }
 
     @PrePersist
     protected void onCreate() {

--- a/src/test/java/com/kodilla/ecommercee/repository/GrupRepositoryTestSuite.java
+++ b/src/test/java/com/kodilla/ecommercee/repository/GrupRepositoryTestSuite.java
@@ -1,0 +1,130 @@
+package com.kodilla.ecommercee.repository;
+
+import com.kodilla.ecommercee.domain.Group;
+import com.kodilla.ecommercee.domain.Product;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class GrupRepositoryTestSuite {
+
+    @Autowired
+    private GroupRepository groupRepository;
+    @Autowired
+    private ProductRepository productRepository;
+
+    @BeforeEach
+    void setUp() {
+        groupRepository.deleteAll();
+        productRepository.deleteAll();
+    }
+
+    @DisplayName("Should save a group and verify it exists with correct details in the repository")
+    @Test
+    void testSaveGroup() {
+        //given
+        Group group = new Group("group", "description");
+        //when
+        Group savedGruop = groupRepository.save(group);
+        Optional<Group> retrievedGruop = groupRepository.findById(savedGruop.getId());
+        //then
+        assertTrue(retrievedGruop.isPresent());
+        assertEquals(group.getId(), retrievedGruop.get().getId());
+        assertEquals(group.getName(), retrievedGruop.get().getName());
+        assertEquals(group.getDescription(), retrievedGruop.get().getDescription());
+    }
+
+    @DisplayName("Should retrieve all groups from the repository")
+    @Test
+    void testGetAllGroups() {
+        //given
+        Group group1 = new Group("group1", "description1");
+        Group group2 = new Group("group2", "description2");
+        groupRepository.save(group1);
+        groupRepository.save(group2);
+        //when
+        List<Group> retrievedGroups = groupRepository.findAll();
+        //then
+        assertEquals(2, retrievedGroups.size());
+    }
+
+    @DisplayName("Should update group name and description")
+    @Test
+    void testUpdateGroup() {
+        //given
+        Group group = new Group("group", "description");
+        Group savedGroup = groupRepository.save(group);
+        //when
+        savedGroup.setName("new name");
+        savedGroup.setDescription("new description");
+        groupRepository.save(savedGroup);
+        Optional<Group> retrievedGroup = groupRepository.findById(savedGroup.getId());
+        //then
+        assertEquals(savedGroup.getId(), retrievedGroup.get().getId());
+        assertEquals(savedGroup.getName(), retrievedGroup.get().getName());
+        assertEquals(savedGroup.getDescription(), retrievedGroup.get().getDescription());
+    }
+
+    @DisplayName("Should delete an empty group")
+    @Test
+    void testDeleteEmptyGroup() {
+        //given
+        Group group = new Group("group", "description");
+        Group savedGroup = groupRepository.save(group);
+        //when
+        groupRepository.delete(savedGroup);
+        Optional<Group> retrievedGroup = groupRepository.findById(savedGroup.getId());
+        //then
+        assertTrue(retrievedGroup.isEmpty());
+    }
+
+    @DisplayName("Should delete groups and detach products, setting their group to null")
+    @Test
+    void testDeleteGroupWithProducts() {
+        //given
+        Group group = new Group("group", "description");
+        Group savedGroup = groupRepository.save(group);
+        Product product = new Product("product", "description", new BigDecimal(1), 1, group);
+        Product savedProduct = productRepository.save(product);
+        //when
+        groupRepository.deleteById(savedGroup.getId());
+        Optional<Product> retrievedProduct = productRepository.findById(savedProduct.getId());
+        //then
+        assertNull(retrievedProduct.get().getGroup());
+    }
+
+    @DisplayName("Should correctly add products to groups and retrieve them by group ID")
+    @Test
+    void testAddProducts() {
+        //given
+        Group group1 = new Group("group1", "description1");
+        Group group2 = new Group("group2", "description2");
+        Group savedGroup1 = groupRepository.save(group1);
+        Group savedGroup2 = groupRepository.save(group2);
+        Product product1 = new Product("product1", "description1", new BigDecimal("1.00"), 1, group1);
+        Product product2 = new Product("product2", "description2", new BigDecimal("2.00"), 2, group1);
+        Product product3 = new Product("product3", "description3", new BigDecimal("3.00"), 3, group1);
+        Product product4 = new Product("product4", "description4", new BigDecimal("4.00"), 4, group2);
+        productRepository.save(product1);
+        productRepository.save(product2);
+        productRepository.save(product3);
+        productRepository.save(product4);
+        //when
+        Optional<Group> retrievedGroup1 = groupRepository.findById(savedGroup1.getId());
+        Optional<Group> retrievedGroup2 = groupRepository.findById(savedGroup2.getId());
+        Product retrievedProduct1 = retrievedGroup1.get().getProducts().get(0);
+        //then
+        assertEquals(3, retrievedGroup1.get().getProducts().size());
+        assertEquals(1, retrievedGroup2.get().getProducts().size());
+        assertEquals(product1.getId(), retrievedProduct1.getId());
+    }
+}


### PR DESCRIPTION
- Created a test suite for the GroupRepository
- Changed the cascadeType for the 'products' field in the 'Group' class to allow deletion of a group with products. 
- Added custom constructors and @Setter annotations for the 'Product' and 'Group' classes and deleted @NotNull annotations 
- Added @PreRemove method in the 'Group' class to set all product's groups to null after group deletion